### PR TITLE
Avoid opening a tab on ctrl-left click

### DIFF
--- a/lib/tab-bar-view.coffee
+++ b/lib/tab-bar-view.coffee
@@ -57,14 +57,14 @@ class TabBarView extends View
 
     @on 'mousedown', '.tab', ({target, which, ctrlKey}) =>
       tab = $(target).closest('.tab')[0]
-      if which is 1 and not target.classList.contains('close-icon')
-        @pane.activateItem(tab.item)
-        @pane.activate()
-        true
-      else if which is 3 or (which is 1 and ctrlKey is true)
+      if which is 3 or (which is 1 and ctrlKey is true)
         @find('.right-clicked').removeClass('right-clicked')
         tab.classList.add('right-clicked')
         false
+      else if which is 1 and not target.classList.contains('close-icon')
+        @pane.activateItem(tab.item)
+        @pane.activate()
+        true
       else if which is 2
         @pane.destroyItem(tab.item)
         false

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -187,7 +187,7 @@ describe "TabBarView", ->
       $(tabBar.tabAtIndex(0)).trigger {type: 'mousedown', which: 1, ctrlKey: true}
       expect(pane.getActiveItem()).not.toBe pane.getItems()[0]
 
-      expect(pane.activate.callCount).toBe 0
+      expect(pane.activate).not.toHaveBeenCalled()
 
   describe "when a tab's close icon is clicked", ->
     it "destroys the tab's item on the pane", ->

--- a/spec/tabs-spec.coffee
+++ b/spec/tabs-spec.coffee
@@ -178,6 +178,17 @@ describe "TabBarView", ->
       expect(tabBar.getTabs().length).toBe 2
       expect(tabBar.find('.tab:contains(sample.js)')).not.toExist()
 
+    it "doesn't switch tab when right (or ctrl-left) clicked", ->
+      spyOn(pane, 'activate')
+
+      $(tabBar.tabAtIndex(0)).trigger {type: 'mousedown', which: 3}
+      expect(pane.getActiveItem()).not.toBe pane.getItems()[0]
+
+      $(tabBar.tabAtIndex(0)).trigger {type: 'mousedown', which: 1, ctrlKey: true}
+      expect(pane.getActiveItem()).not.toBe pane.getItems()[0]
+
+      expect(pane.activate.callCount).toBe 0
+
   describe "when a tab's close icon is clicked", ->
     it "destroys the tab's item on the pane", ->
       $(tabBar.tabForItem(editor1)).find('.close-icon').click()


### PR DESCRIPTION
* :white_check_mark: Document right-click (and ctrlKey) behavior